### PR TITLE
dcc-5646-blocking-endpoints

### DIFF
--- a/song-client/src/main/java/org/icgc/dcc/song/client/command/UploadCommand.java
+++ b/song-client/src/main/java/org/icgc/dcc/song/client/command/UploadCommand.java
@@ -18,23 +18,24 @@
  */
 package org.icgc.dcc.song.client.command;
 
-import java.io.File;
-import java.io.IOException;
-
-import org.icgc.dcc.song.client.register.Registry;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
-
 import lombok.val;
+import org.icgc.dcc.song.client.register.Registry;
+
+import java.io.File;
+import java.io.IOException;
 
 @Parameters(separators = "=", commandDescription = "Upload an analysis file, and get an upload id")
 public class UploadCommand extends Command {
 
   @Parameter(names = { "-f", "--file" }, required = true)
   String fileName;
+
+  @Parameter(names = { "-a", "--async" },description = "Enables asynchronous validation")
+  boolean isAsyncValidation = false;
 
   Registry registry;
 
@@ -52,8 +53,7 @@ public class UploadCommand extends Command {
       err("Error: Can't open file '%s'", file);
       return;
     }
-
-    val status = registry.upload(json);
+    val status = registry.upload(json, isAsyncValidation);
     save(status);
   }
 

--- a/song-client/src/main/java/org/icgc/dcc/song/client/register/Endpoint.java
+++ b/song-client/src/main/java/org/icgc/dcc/song/client/register/Endpoint.java
@@ -31,8 +31,12 @@ public class Endpoint {
     this.serverUrl = serverUrl;
   }
 
-  String upload(String studyId) {
-    return format("%s/upload/%s", serverUrl, studyId);
+  String upload(String studyId, boolean isAsyncValidation) {
+    if (isAsyncValidation){
+      return format("%s/upload/%s/async", serverUrl, studyId);
+    } else {
+      return format("%s/upload/%s", serverUrl, studyId);
+    }
   }
 
   public String saveById(String studyId, String uploadId) {

--- a/song-client/src/main/java/org/icgc/dcc/song/client/register/Registry.java
+++ b/song-client/src/main/java/org/icgc/dcc/song/client/register/Registry.java
@@ -69,8 +69,8 @@ public class Registry {
    * @param json
    * @return The analysisId that the server returned, or null if an error occurred.
    */
-  public Status upload(String json) {
-    val url = endpoint.upload(getStudyId(json));
+  public Status upload(String json, boolean isAsyncValidation) {
+    val url = endpoint.upload(getStudyId(json), isAsyncValidation);
     return restClient.post(url, json);
   }
 

--- a/song-core/src/main/java/org/icgc/dcc/song/core/utils/Debug.java
+++ b/song-core/src/main/java/org/icgc/dcc/song/core/utils/Debug.java
@@ -29,6 +29,14 @@ public class Debug {
         .skip(2);
   }
 
+  public static void sleepMs(long timeMs){
+    try {
+      Thread.sleep(timeMs);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
   public static String generateHeader(String title, int lengthOfHeader, String symbol){
     int t = title.length();
     int n = Math.max(t+2, lengthOfHeader);

--- a/song-server/pom.xml
+++ b/song-server/pom.xml
@@ -16,10 +16,11 @@
             <artifactId>song-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.antlr</groupId>
-            <artifactId>StringTemplate</artifactId>
-            <version>3.2.1</version>
+            <artifactId>stringtemplate</artifactId>
+            <version>${antlr.stringtemplate.version}</version>
         </dependency>
 
         <!-- Spring -->
@@ -202,6 +203,7 @@
         <flyway-spring-test.version>4.1.0</flyway-spring-test.version>
         <postgresql.version>9.4.1208-jdbc42-atlassian-hosted</postgresql.version>
         <springfox.version>2.7.0</springfox.version>
+        <antlr.stringtemplate.version>3.2</antlr.stringtemplate.version>
 
         <!-- Spring Security oath2 -->
         <spring-security-oauth2.version>2.1.0.RELEASE</spring-security-oauth2.version>

--- a/song-server/pom.xml
+++ b/song-server/pom.xml
@@ -16,6 +16,11 @@
             <artifactId>song-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>StringTemplate</artifactId>
+            <version>3.2.1</version>
+        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/song-server/pom.xml
+++ b/song-server/pom.xml
@@ -17,12 +17,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>stringtemplate</artifactId>
-            <version>${antlr.stringtemplate.version}</version>
-        </dependency>
-
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -203,7 +197,6 @@
         <flyway-spring-test.version>4.1.0</flyway-spring-test.version>
         <postgresql.version>9.4.1208-jdbc42-atlassian-hosted</postgresql.version>
         <springfox.version>2.7.0</springfox.version>
-        <antlr.stringtemplate.version>3.2</antlr.stringtemplate.version>
 
         <!-- Spring Security oath2 -->
         <spring-security-oauth2.version>2.1.0.RELEASE</spring-security-oauth2.version>

--- a/song-server/src/main/java/org/icgc/dcc/song/server/config/ValidationConfig.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/config/ValidationConfig.java
@@ -29,6 +29,7 @@ import org.icgc.dcc.song.core.utils.JsonSchemaUtils;
 import org.icgc.dcc.song.server.validation.SchemaValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +46,12 @@ public class ValidationConfig {
   @Bean
   public SchemaValidator schemaValidator() {
     return new SchemaValidator();
+  }
+
+  @Bean
+  @Profile("test")
+  public Long validationDelayMs(){
+    return 500L;
   }
 
   @Bean

--- a/song-server/src/main/java/org/icgc/dcc/song/server/config/ValidationConfig.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/config/ValidationConfig.java
@@ -27,6 +27,7 @@ import lombok.val;
 import org.icgc.dcc.song.core.utils.JsonDocUtils;
 import org.icgc.dcc.song.core.utils.JsonSchemaUtils;
 import org.icgc.dcc.song.server.validation.SchemaValidator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -40,8 +41,10 @@ import java.util.Map;
 public class ValidationConfig {
 
   private static String[] schemaList =
-      {"schemas/sequencingRead.json", "schemas/variantCall.json"
-      };
+      {"schemas/sequencingRead.json", "schemas/variantCall.json" };
+
+  @Value("${validation.delayMs:500}")
+  private long validationDelay;
 
   @Bean
   public SchemaValidator schemaValidator() {
@@ -51,7 +54,7 @@ public class ValidationConfig {
   @Bean
   @Profile("test")
   public Long validationDelayMs(){
-    return 500L;
+    return getValidationDelay();
   }
 
   @Bean

--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/UploadController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/UploadController.java
@@ -20,6 +20,7 @@
 package org.icgc.dcc.song.server.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.icgc.dcc.song.server.model.Upload;
 import org.icgc.dcc.song.server.service.UploadService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import javax.validation.Valid;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+@Slf4j
 @RestController
 @RequestMapping(path = "/upload")
 @RequiredArgsConstructor
@@ -51,10 +53,18 @@ public class UploadController {
 
   @PostMapping(value = "/{studyId}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public ResponseEntity<String> upload(
+  public ResponseEntity<String> syncUpload(
       @PathVariable("studyId") String studyId,
-      @RequestBody @Valid String payload) {
-    return uploadService.upload(studyId, payload);
+      @RequestBody @Valid String payload ) {
+    return uploadService.upload(studyId, payload, false);
+  }
+
+  @PostMapping(value = "/{studyId}/async", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+  public ResponseEntity<String> asyncUpload(
+      @PathVariable("studyId") String studyId,
+      @RequestBody @Valid String payload ) {
+    return uploadService.upload(studyId, payload, true);
   }
 
   @GetMapping(value = "/{studyId}/status/{uploadId}")

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/UploadRepository.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/UploadRepository.java
@@ -24,14 +24,9 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.unstable.BindIn;
-
-import java.util.List;
 
 //TODO: [DCC-5643] Cleanup SQLQueries to reference constants
 @RegisterMapper(UploadMapper.class)
-@UseStringTemplate3StatementLocator
 public interface UploadRepository {
 
   @SqlUpdate("INSERT INTO upload (id, study_id, state, payload, updated_at) VALUES (:id, :studyId, :state, :payload, now())")
@@ -44,8 +39,5 @@ public interface UploadRepository {
 
   @SqlQuery("SELECT id, study_id, state, created_at, updated_at, errors, payload FROM upload WHERE id = :uploadId")
   Upload get(@Bind("uploadId") String id);
-
-  @SqlQuery("SELECT id, study_id, state, created_at, updated_at, errors, payload FROM upload WHERE id in (<uploadIdList>)")
-  List<Upload> getList(@BindIn("uploadIdList")  List<String> uploadIdList);
 
 }

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/UploadRepository.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/UploadRepository.java
@@ -24,8 +24,14 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.unstable.BindIn;
+
+import java.util.List;
+
 //TODO: [DCC-5643] Cleanup SQLQueries to reference constants
 @RegisterMapper(UploadMapper.class)
+@UseStringTemplate3StatementLocator
 public interface UploadRepository {
 
   @SqlUpdate("INSERT INTO upload (id, study_id, state, payload, updated_at) VALUES (:id, :studyId, :state, :payload, now())")
@@ -38,4 +44,8 @@ public interface UploadRepository {
 
   @SqlQuery("SELECT id, study_id, state, created_at, updated_at, errors, payload FROM upload WHERE id = :uploadId")
   Upload get(@Bind("uploadId") String id);
+
+  @SqlQuery("SELECT id, study_id, state, created_at, updated_at, errors, payload FROM upload WHERE id in (<uploadIdList>)")
+  List<Upload> getList(@BindIn("uploadIdList")  List<String> uploadIdList);
+
 }

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
@@ -34,6 +34,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.ANALYSIS_ID_NOT_CREATED;
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.PAYLOAD_PARSING;
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.UPLOAD_ID_NOT_FOUND;
@@ -62,6 +64,10 @@ public class UploadService {
 
   public Upload read(@NonNull String uploadId) {
     return uploadRepository.get(uploadId);
+  }
+
+  public List<Upload> readList(@NonNull List<String> uploadIds) {
+    return uploadRepository.getList(uploadIds);
   }
 
   private void create(@NonNull String studyId, @NonNull String uploadId, @NonNull String jsonPayload) {

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
@@ -34,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.ANALYSIS_ID_NOT_CREATED;
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.PAYLOAD_PARSING;
 import static org.icgc.dcc.song.core.exceptions.ServerErrors.UPLOAD_ID_NOT_FOUND;
@@ -64,10 +62,6 @@ public class UploadService {
 
   public Upload read(@NonNull String uploadId) {
     return uploadRepository.get(uploadId);
-  }
-
-  public List<Upload> readList(@NonNull List<String> uploadIds) {
-    return uploadRepository.getList(uploadIds);
   }
 
   private void create(@NonNull String studyId, @NonNull String uploadId, @NonNull String jsonPayload) {

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/UploadService.java
@@ -69,7 +69,7 @@ public class UploadService {
   }
 
   @SneakyThrows
-  public ResponseEntity<String> upload(String studyId, String payload) {
+  public ResponseEntity<String> upload(String studyId, String payload, boolean isAsyncValidation) {
     val uploadId = id.generate(IdPrefix.Upload);
     String analysisType;
     try {
@@ -88,7 +88,11 @@ public class UploadService {
           "Unable parse the input payload: %s ",payload);
     }
 
-    validator.validate(uploadId, payload, analysisType); // Async operation.
+    if (isAsyncValidation){
+      validator.asyncValidate(uploadId, payload, analysisType); // Asynchronous operation.
+    } else {
+      validator.syncValidate(uploadId, payload, analysisType); // Synchronous operation
+    }
     return ok(uploadId);
   }
 

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
@@ -36,6 +36,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import static java.lang.String.format;
+import static org.icgc.dcc.song.core.utils.Debug.sleepMs;
 
 @Slf4j
 @Service
@@ -44,6 +45,9 @@ public class ValidationService {
 
   @Autowired
   private SchemaValidator validator;
+
+  @Autowired(required = false)
+  private Long validationDelayMs = -1L;
 
   protected static final ObjectMapper mapper = new ObjectMapper().registerModule(new ParameterNamesModule())
       .registerModule(new Jdk8Module())
@@ -62,6 +66,7 @@ public class ValidationService {
   }
 
   public void syncValidate(@NonNull String uploadId, @NonNull String payload, String analysisType) {
+    debugDelay();
     log.info("Validating payload for upload Id=" + uploadId + "payload=" + payload);
     log.info(format("Analysis type='%s'",analysisType));
     try {
@@ -85,6 +90,18 @@ public class ValidationService {
     } catch (Exception e) {
       log.error(e.getMessage());
       updateAsInvalid(uploadId, format("Unknown processing problem: %s", e.getMessage()));
+    }
+
+  }
+
+  /**
+   * Creates an artificial delay for testing purposes.
+   * The validationDelayMs should be controlled through the Spring "test" profile
+   */
+  private void debugDelay(){
+    if (validationDelayMs > -1){
+      log.info("Sleeping for {} ms", validationDelayMs);
+      sleepMs(validationDelayMs);
     }
   }
 

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
@@ -57,7 +57,11 @@ public class ValidationService {
   }
 
   @Async
-  public void validate(@NonNull String uploadId, @NonNull String payload, String analysisType) {
+  public void asyncValidate(@NonNull String uploadId, @NonNull String payload, String analysisType) {
+    syncValidate(uploadId, payload, analysisType);
+  }
+
+  public void syncValidate(@NonNull String uploadId, @NonNull String payload, String analysisType) {
     log.info("Validating payload for upload Id=" + uploadId + "payload=" + payload);
     log.info(format("Analysis type='%s'",analysisType));
     try {

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -42,6 +42,8 @@ validation:
 flyway:
   baselineOnMigrate: true
 
+validation.delayMs: 600
+
 auth:
   # Connection retries in case of connection failure
   connection:

--- a/song-server/src/test/java/org/icgc/dcc/song/server/service/UploadServiceTest.java
+++ b/song-server/src/test/java/org/icgc/dcc/song/server/service/UploadServiceTest.java
@@ -22,7 +22,6 @@ import lombok.SneakyThrows;
 import lombok.val;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.flywaydb.test.junit.FlywayTestExecutionListener;
-
 import org.icgc.dcc.song.server.model.Upload;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,31 +32,82 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import java.nio.file.*;
+import java.nio.file.Files;
 
-import static org.springframework.http.HttpStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, FlywayTestExecutionListener.class })
 @FlywayTest
-@ActiveProfiles({"dev", "secure"})
+@ActiveProfiles({"dev", "secure", "test"})
 public class UploadServiceTest {
 
   @Autowired
   UploadService uploadService;
 
   @Test
-  @SneakyThrows
-  public void testSequencingRead() {
-    test("sequencingRead.json");
+  public void testAsyncSequencingRead(){
+    testSequencingRead(true);
   }
 
   @Test
+  public void testSyncSequencingRead(){
+    testSequencingRead(false);
+  }
+
+  @Test
+  public void testAsyncVariantCall(){
+    testVariantCall(true);
+  }
+
+  @Test
+  public void testSyncVariantCall(){
+    testVariantCall(false);
+  }
+
+  @Test
+  public void testSyncUploadNoCreated(){
+    val fileName = "sequencingRead.json";
+    val study="ABC123";
+    val json = readFile(fileName);
+    val uploadStatus = uploadService.upload(study, json, false );
+    val uploadId = uploadStatus.getBody().toString();
+    val upload = uploadService.read(uploadId);
+    assertThat(upload.getState()).isNotEqualTo("CREATED"); //Since validation done synchronously, validation cannot ever return with the CREATED state
+  }
+
+  @Test
+  public void testSyncUpload(){
+    val fileName = "sequencingRead.json";
+    val study="ABC123";
+    val json = readFile(fileName);
+    val uploadStatus = uploadService.upload(study, json, false );
+    val uploadId = uploadStatus.getBody().toString();
+    val upload = uploadService.read(uploadId);
+    assertThat(upload.getState()).isEqualTo("VALIDATED");
+  }
+
+  @Test
+  public void testASyncUpload(){
+    val fileName = "sequencingRead.json";
+    val study="ABC123";
+    val json = readFile(fileName);
+    val uploadStatus = uploadService.upload(study, json, true );
+    val uploadId = uploadStatus.getBody().toString();
+    val upload = uploadService.read(uploadId);
+    assertThat(upload.getState()).isEqualTo("CREATED");
+  }
+
   @SneakyThrows
-  public void testVariantCall() {
-    test("variantCall.json");
+  private void testSequencingRead(final boolean isAsyncValidation) {
+    test("sequencingRead.json", isAsyncValidation);
+  }
+
+  @SneakyThrows
+  private void testVariantCall(final boolean isAsyncValidation) {
+    test("variantCall.json", isAsyncValidation);
   }
 
   @SneakyThrows
@@ -65,12 +115,12 @@ public class UploadServiceTest {
     return new String(Files.readAllBytes(new java.io.File("..", name).toPath()));
   }
 
-  public String read(String uploadId) {
+  private String read(String uploadId) {
     Upload status = uploadService.read(uploadId);
     return status.getState();
   }
 
-  public String validate(String uploadId) throws InterruptedException {
+  private String validate(String uploadId) throws InterruptedException {
     String state=read(uploadId);
     // wait for the server to finish
     while(state.equals("CREATED")) {
@@ -81,19 +131,23 @@ public class UploadServiceTest {
   }
 
   @SneakyThrows
-  public void test(String fileName) {
+  private void test(String fileName, boolean isAsyncValidation) {
     val study="ABC123";
     val json = readFile(fileName);
 
     // test upload
-    val uploadStatus=uploadService.upload(study, json);
+    val uploadStatus=uploadService.upload(study, json, isAsyncValidation);
     assertThat(uploadStatus.getStatusCode()).isEqualTo(OK);
     val uploadId=uploadStatus.getBody().toString();
     assertThat(uploadId.startsWith("UP")).isTrue();
 
-    // test create
     val initialState = read(uploadId);
-    assertThat(initialState).isEqualTo("CREATED");
+    if (isAsyncValidation){
+      // test create for Asynchronous case
+      assertThat(initialState).isEqualTo("CREATED");
+    } else {
+      assertThat(initialState).isEqualTo("VALIDATED"); //Syncronous should always return VALIDATED
+    }
 
     // test validation
     val finalState = validate(uploadId);


### PR DESCRIPTION
- added async and sync validation
- added async and sync option for upload endpoint (synchronous being the default)
- added validationDelay functionality inside valdiationService.validate() method, for testing purposes (should only be used in when the "test" profile is set in spring)
- added async and sync tests (sync tests should NEVER see the state "CREATED", where async test SHOULD see it)
- added getList sql command to UploadRepository to get multiple Upload objects for a list of upload ids
- added "-a" and "--async" boolean switch to UploadCommand in song-client that calls the async upload endpoint when defined, and the sync upload endpoint when not defined