### PR TITLE
parameterized validation delay

### DIFF
--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/ValidationService.java
@@ -36,7 +36,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import static java.lang.String.format;
-import static org.icgc.dcc.song.core.utils.Debug.sleepMs;
 
 @Slf4j
 @Service
@@ -66,7 +65,6 @@ public class ValidationService {
   }
 
   public void syncValidate(@NonNull String uploadId, @NonNull String payload, String analysisType) {
-    debugDelay();
     log.info("Validating payload for upload Id=" + uploadId + "payload=" + payload);
     log.info(format("Analysis type='%s'",analysisType));
     try {
@@ -94,16 +92,6 @@ public class ValidationService {
 
   }
 
-  /**
-   * Creates an artificial delay for testing purposes.
-   * The validationDelayMs should be controlled through the Spring "test" profile
-   */
-  private void debugDelay(){
-    if (validationDelayMs > -1){
-      log.info("Sleeping for {} ms", validationDelayMs);
-      sleepMs(validationDelayMs);
-    }
-  }
 
   private void updateAsValid(@NonNull String uploadId) {
     uploadRepository.update(uploadId, Upload.VALIDATED, "");

--- a/song-server/src/main/java/org/icgc/dcc/song/server/validation/SchemaValidator.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/validation/SchemaValidator.java
@@ -18,16 +18,14 @@
  */
 package org.icgc.dcc.song.server.validation;
 
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.JsonSchema;
-
 import lombok.SneakyThrows;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
 
 /**
  * Potentially extract a Validator interface if we want to pursue a Strategy pattern of multiple validation rules or
@@ -40,6 +38,9 @@ public class SchemaValidator {
   @Autowired
   private Map<String, JsonSchema> schemaCache;
 
+  @Autowired(required = false)
+  private Long validationDelayMs = -1L;
+
   @SneakyThrows
   public ValidationResponse validate(String schemaId, JsonNode payloadRoot) {
     if (schemaCache.containsKey(schemaId)) {
@@ -48,7 +49,7 @@ public class SchemaValidator {
       val response = new ValidationResponse(results);
       log.info(response.getValidationErrors());
 
-      Thread.sleep(2500);
+      debugDelay();
 
       return response;
     } else {
@@ -57,4 +58,15 @@ public class SchemaValidator {
     }
   }
 
+  /**
+   * Creates an artificial delay for testing purposes.
+   * The validationDelayMs should be controlled through the Spring "test" profile
+   */
+  @SneakyThrows
+  private void debugDelay(){
+    if (validationDelayMs > -1){
+      log.info("Sleeping for {} ms", validationDelayMs);
+      Thread.sleep(validationDelayMs);
+    }
+  }
 }

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -42,7 +42,7 @@ validation:
 flyway:
   baselineOnMigrate: true
 
-validation.delayMs: 600
+validation.delayMs: 3000
 
 auth:
   # Connection retries in case of connection failure

--- a/song-server/src/test/java/org/icgc/dcc/song/server/service/UploadServiceTest.java
+++ b/song-server/src/test/java/org/icgc/dcc/song/server/service/UploadServiceTest.java
@@ -146,7 +146,7 @@ public class UploadServiceTest {
       // test create for Asynchronous case
       assertThat(initialState).isEqualTo("CREATED");
     } else {
-      assertThat(initialState).isEqualTo("VALIDATED"); //Syncronous should always return VALIDATED
+      assertThat(initialState).isEqualTo("VALIDATED"); //Synchronous should always return VALIDATED
     }
 
     // test validation


### PR DESCRIPTION
- parameterized validation delay to be set via application.yml, and only activated in the "test" profile. If the active profile is not "test", then the validation delay is bypassed completely.