### PR TITLE
Change: In the File table, each file is now directly associated with …

### DIFF
--- a/METADATA_RULES.md
+++ b/METADATA_RULES.md
@@ -5,26 +5,23 @@
 
 **Running your own SONG server**
 - To run your own SONG server to track metadata you've uploaded to a storage repository,  you need:
-  - For data security, an Oath2 authorization server (we use ...) 
-  - An id token generation server (we use the ... protocol) 
-  - Access to a storage repository 
-    - A Java API for that storage repository (we support S3 and native storage,
-	but it should be easy to extend to other APIs; all you have to do is
-        show SONG how to ask the storage repository if a file exists or not) 
-    - A Java interface to access that storage repository from SONG, so that the SONG server can verify that a given file was successfully uploaded to the straoge repository (we currently have an interface for the S3 storage repository API; but it should be easy to create interfaces to check the contents of other storage APIs, as well)
   - A server to run SONG on, with Java 8, maven, and PostgresSQL 
+  - An id server 
+  - For data security, an Oath2 authorization server [optional] 
+  - Access to a storage repository 
+  - A Java interface to access that storage repository from SONG, so that the SONG server can verify that a given file was successfully uploaded to the straoge repository (we currently have an interface for the S3 storage repository API; but it should be easy to create interfaces to check the contents of other storage APIs, as well)
+
+If you have Docker installed and running on your machine, you can just run 'docker-compose build;docker-compose up' in the docker directory to get started with SONG
 
 **About SING**
 
 - SING is our client program to upload, verify, and query metadata stored on a SONG metadata server; which references a corresponding data upload server which
 stores the actual data files. 
-- The metadata files you upload must be written according to the JSON specification given at <INSERT FILE PATH HERE> 
-- Each JSON file must contain the following fields:
-  - study _The study id that the SONG server administrator gave you when (s)he added your study to the SONG server, and gave you your access token to access it_    
+- The metadata files you upload must be written according to the JSON schemas located in the directory song-server/main/resources/schemas 
+
 **Metadata Upload Rules**
-- Every upload that you save creates a new analysis, with it's own unique
-analysis id. If you upload and save the same metadata six times, you will create six distinct analyses, with six distinct analysis ids.
+- If you don't include a unique "analysisSubmitterId" in your JSON file, we will create a new upload id (and new analysis) for each submitter. 
 - Every field in the analysis metadata has to be included with every upload; no partial uploads are allowed.
-- When you save an upload, if you change the content of previous metadata that you have provided, (such as specifying a different gender for a given donor with a given donor id), we will update the metadata with your changes, and inform you about what has changed in the reply we send you. 
+- When you upload metadata with the same analysisSubmitterId as a previous upload, we will replace the metadata with the new version, and the reply message will include a warning message and the previous version of the metadata. 
 - You cannot change any existing sample/specimen/donor parent-child relationships when you publish an analysis; and we will return an error if you try.
 

--- a/song-server/src/main/java/org/icgc/dcc/song/server/model/entity/File.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/model/entity/File.java
@@ -34,16 +34,18 @@ import org.icgc.dcc.song.server.model.enums.Constants;
 public class File extends Metadata {
 
   private String objectId = "";
+  private String analysisId = "";
   private String fileName = "";
   private String studyId = "";
   private Long fileSize = -1L;
   private String fileType = "";
   private String fileMd5sum = "";
 
-  public static File create(String id, String name, String study, Long size, String type, String md5,
+  public static File create(String id, String analysisId, String name, String study, Long size, String type, String md5,
       String metadata) {
     val f = new File();
     f.setObjectId(id);
+    f.setAnalysisId(analysisId);
     f.setFileName(name);
     f.setStudyId(study);
     f.setFileSize(size);

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/AnalysisRepository.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/AnalysisRepository.java
@@ -62,13 +62,10 @@ public interface AnalysisRepository {
   @SqlQuery("SELECT id, study_id, submitter_id, type, state, info FROM Analysis WHERE id=:id")
   Analysis read(@Bind("id") String id);
 
-  @SqlQuery("SELECT f.id, f.name, f.study_id, f.size, f.type, f.md5, f.info "
-      + "FROM File f, FileSet s "
-      + "WHERE s.analysis_id=:analysisId "
-      + "  AND f.id = s.file_id")
-  List<File> readFiles(@Bind("analysisId") String id);
+  @SqlQuery("SELECT id, analysis_id, name, study_id, size, type, md5, info  FROM File WHERE analysis_id=:id ")
+  List<File> readFiles(@Bind("id") String id);
 
-  @SqlUpdate("DELETE FROM file f WHERE f.id IN (SELECT fs.file_id FROM fileset fs WHERE fs.analysis_id=:id)")
+  @SqlUpdate("DELETE FROM File WHERE analysis_id=:id")
   void deleteFiles(@Bind("id") String analysisId);
 
   @SqlUpdate("DELETE FROM SampleSet WHERE analysis_id=:id")

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/AttributeNames.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/AttributeNames.java
@@ -26,6 +26,8 @@ public class AttributeNames {
     public static final String DONOR_ID="donor_id";
     public static final String CLASS="class";
 
+    public static final String ANALYSIS_ID="analysis_id";
+
     public static final String ORGANIZATION="organization";
     public static final String DESCRIPTION="description";
 

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/FileRepository.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/FileRepository.java
@@ -31,25 +31,25 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 @RegisterMapper(FileMapper.class)
 public interface FileRepository {
 
-  @SqlUpdate("INSERT INTO File (id,name, study_id, size, type, md5, info) "
-      + "VALUES (:objectId, :fileName, :studyId, :fileSize, :fileType, :fileMd5sum, :info)")
+  @SqlUpdate("INSERT INTO File (id, analysis_id, name, study_id, size, type, md5, info) "
+      + "VALUES (:objectId, :analysisId,:fileName,  :studyId, :fileSize, :fileType, :fileMd5sum, :info)")
   int create(@BindBean File f);
 
-  @SqlQuery("SELECT id, name, study_id, size, type, md5, info FROM File WHERE id=:id")
+  @SqlQuery("SELECT id, analysis_id, name, study_id, size, type, md5, info FROM File WHERE id=:id")
   File read(@Bind("id") String id);
 
-  @SqlUpdate("UPDATE File SET name=:fileName, size=:fileSize, type=:fileType, md5=:fileMd5sum, info=:info where id=:objectId")
+  @SqlUpdate("UPDATE File SET name=:fileName, analysis_id=:analysisId, size=:fileSize, type=:fileType, md5=:fileMd5sum, info=:info where id=:objectId")
   int update(@BindBean File file);
 
-  @SqlUpdate("UPDATE File SET name=:fileName, size=:fileSize, type=:fileType, md5=:fileMd5, metadata_doc=:metadata where id=:id")
+  @SqlUpdate("UPDATE File SET name=:fileName, analysis_id=:analysisId,size=:fileSize, type=:fileType, md5=:fileMd5, metadata_doc=:metadata where id=:id")
   int update(@Bind("id") String id, @BindBean File file);
 
   @SqlUpdate("DELETE From File where id=:id")
   int delete(@Bind("id") String id);
 
-  @SqlQuery("SELECT id, name, study_id, size, type, md5, info FROM File WHERE study_id=:studyId")
+  @SqlQuery("SELECT id, analysis_id, name, study_id, size, type, md5, info FROM File WHERE study_id=:studyId")
   List<File> readByParentId(@Bind("studyId") String study_id);
 
-  @SqlQuery("SELECT f.id from File f, FileSet fs WHERE f.name=:fileName AND fs.analysis_id=:analysisId AND f.id=fs.file_id")
+  @SqlQuery("SELECT f.id from File f WHERE f.name=:fileName AND f.analysis_id=:analysisId")
   String findByBusinessKey(@Bind("analysisId") String analysisId, @Bind("fileName") String fileName);
 }

--- a/song-server/src/main/java/org/icgc/dcc/song/server/repository/mapper/FileMapper.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/repository/mapper/FileMapper.java
@@ -31,7 +31,7 @@ public class FileMapper implements ResultSetMapper<File> {
 
   @Override
   public File map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-    return File.create(r.getString(ID), r.getString(NAME), r.getString(STUDY_ID),
+    return File.create(r.getString(ID), r.getString(ANALYSIS_ID), r.getString(NAME), r.getString(STUDY_ID),
         r.getLong(SIZE), r.getString(TYPE), r.getString(MD5),
             r.getString(INFO));
   }

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/AnalysisService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/AnalysisService.java
@@ -101,15 +101,8 @@ public class AnalysisService {
   }
 
   void saveFiles(String id, String studyId, List<File> files) {
-    files.stream()
-            .map(f->fileService.save(id, studyId, f))
-            .forEach(fileId->addFile(id, fileId));
+    files.stream().map(f->fileService.save(id, studyId, f));
   }
-
-  void addFile(String id, String fileId) {
-    repository.addFile(id, fileId);
-  }
-
 
   /**
    * Gets all analysis for a given study.

--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/FileService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/FileService.java
@@ -45,6 +45,7 @@ public class FileService {
     val id = idService.generateFileId(analysisId, file.getFileName());
     file.setObjectId(id);
     file.setStudyId(studyId);
+    file.setAnalysisId(analysisId);
 
     val status = repository.create(file);
 
@@ -75,6 +76,7 @@ public class FileService {
       fileId = idService.generateFileId(analysisId, file.getFileName());
       file.setObjectId(fileId);
       file.setStudyId(studyId);
+      file.setAnalysisId(analysisId);
       val status=repository.create(file);
       if (status==-1) {
         throw buildServerException(this.getClass(), FILE_RECORD_FAILED, "Cannot create File: %s", file.toString());

--- a/song-server/src/main/resources/db/migration/data/V2__defaultdata.sql
+++ b/song-server/src/main/resources/db/migration/data/V2__defaultdata.sql
@@ -7,21 +7,18 @@ insert into Specimen (id, donor_id, submitter_id, class, type) values ('SP2','DO
 insert into Sample (id, specimen_id, submitter_id, type) values ('SA1', 'SP1', 'T285-G7-A5','DNA');
 insert into Sample (id, specimen_id, submitter_id, type) values ('SA11', 'SP1', 'T285-G7-B9','DNA');
 insert into Sample (id, specimen_id, submitter_id, type) values ('SA21', 'SP2', 'T285-G7N','DNA');
-insert into File (id, study_id, name, size, type, md5, info) values ('FI1', 'ABC123', 'ABC-TC285G7-A5-ae3458712345.bam', 122333444455555, 'BAM', '20de2982390c60e33452bf8736c3a9f1', '<XML>Not even well-formed <XML></XML>');
-insert into File (id, study_id, name, size, type, md5, info) values ('FI2', 'ABC123', 'ABC-TC285G7-A5-wleazprt453.bai', 123456789, 'BAI', '53ae1343e3ae333ac24c5a2e6279a21d', '<XML>Not even well-formed<XML></XML>');
-insert into File(id, study_id, name, size, type, md5, info) values ('FI3', 'ABC123', 'ABC-TC285-G7-B9-kthx12345.bai', 23456789, 'BAI', '0f41f4e4619e5731447432d101bcfb34', '<XML><Status>Inconclusive</Status></XML>');
-insert into File(id, study_id, name, size, type, md5, info) values ('FI4', 'ABC123', 'ABC-TC285-G7N-alpha12345.fai', 12345, 'FAI', '1ad22383391004fd12441f39ba7f2380', '<XML></XML>');
-
 
 insert into Analysis(id, study_id, state, type) values('AN1','ABC123', 'UNPUBLISHED', 'variantCall');
 insert into VariantCall(id, variant_calling_tool) values ('AN1','SuperNewVariantCallingTool');
-insert into FileSet(analysis_id, file_id) values ('AN1', 'FI1'),('AN1','FI2');
-
 
 insert into Analysis(id, study_id, state, type) values ('AN2','ABC123', 'UNPUBLISHED','sequencingRead');
 insert into SequencingRead (id, library_strategy, paired_end, insert_size, aligned, alignment_tool, reference_genome) values ('AN2','Other', TRUE, 12345, TRUE, 'BigWrench', 'hg19');
-insert into FileSet(analysis_id, file_id) values ('AN2', 'FI1'),('AN2','FI3');
 
 insert into SampleSet(analysis_id, sample_id) values ('AN2','SA1');
 insert into SampleSet(analysis_id, sample_id) values ('AN1', 'SA11');
 insert into SampleSet(analysis_id, sample_id) values ('AN1', 'SA21');
+
+insert into File (id, analysis_id, study_id, name, size, type, md5, info) values ('FI1', 'AN1', 'ABC123', 'ABC-TC285G7-A5-ae3458712345.bam', 122333444455555, 'BAM', '20de2982390c60e33452bf8736c3a9f1', '<XML>Not even well-formed <XML></XML>');
+insert into File (id, analysis_id, study_id, name, size, type, md5, info) values ('FI2', 'AN1', 'ABC123', 'ABC-TC285G7-A5-wleazprt453.bai', 123456789, 'BAI', '53ae1343e3ae333ac24c5a2e6279a21d', '<XML>Not even well-formed<XML></XML>');
+insert into File(id, analysis_id, study_id, name, size, type, md5, info) values ('FI3', 'AN2', 'ABC123', 'ABC-TC285-G7-B9-kthx12345.bai', 23456789, 'BAI', '0f41f4e4619e5731447432d101bcfb34', '<XML><Status>Inconclusive</Status></XML>');
+insert into File(id, analysis_id, study_id, name, size, type, md5, info) values ('FI4', 'AN2', 'ABC123', 'ABC-TC285-G7N-alpha12345.fai', 12345, 'FAI', '1ad22383391004fd12441f39ba7f2380', '<XML></XML>');

--- a/song-server/src/main/resources/db/migration/h2/V1__init.sql
+++ b/song-server/src/main/resources/db/migration/h2/V1__init.sql
@@ -65,12 +65,11 @@ CREATE TABLE Specimen(id VARCHAR(36) PRIMARY KEY, donor_id VARCHAR(36) reference
     class SPECIMEN_CLASS, type SPECIMEN_TYPE, info TEXT);
 CREATE TABLE Sample(id VARCHAR(36) PRIMARY KEY, specimen_id VARCHAR(36) references Specimen, submitter_id TEXT,
     type SAMPLE_TYPE, info TEXT);
-CREATE TABLE File(id VARCHAR(36) PRIMARY KEY, study_id VARCHAR(36) references Study, name TEXT, size BIGINT,
-    md5 CHAR(32), type FILE_TYPE, info TEXT);
 
 CREATE TABLE Analysis(id VARCHAR(36) PRIMARY KEY, submitter_id TEXT, type ANALYSIS_TYPE, state ANALYSIS_STATE,
     study_id VARCHAR(36) references Study, info TEXT);
-CREATE TABLE FileSet(analysis_id VARCHAR(36) references Analysis, file_id VARCHAR(36) references File ON DELETE CASCADE);
+CREATE TABLE File(id VARCHAR(36) PRIMARY KEY, analysis_id VARCHAR(36) references Analysis, study_id VARCHAR(36) references Study, name TEXT, size BIGINT,
+                  md5 CHAR(32), type FILE_TYPE, info TEXT);
 CREATE TABLE SampleSet(analysis_id VARCHAR(36) references Analysis, sample_id VARCHAR(36) references Sample);
 CREATE TABLE SequencingRead(id VARCHAR(36) references Analysis, library_strategy LIBRARY_STRATEGY, paired_end BOOLEAN,
     insert_size BIGINT, aligned BOOLEAN, alignment_tool TEXT, reference_genome TEXT, info TEXT);

--- a/song-server/src/main/resources/db/migration/postgresql/V1__init.sql
+++ b/song-server/src/main/resources/db/migration/postgresql/V1__init.sql
@@ -62,12 +62,12 @@ CREATE TABLE Specimen(id VARCHAR(36) PRIMARY KEY, donor_id VARCHAR(36) reference
 CREATE TABLE Sample(id VARCHAR(36) PRIMARY KEY, specimen_id VARCHAR(36) references Specimen, submitter_id TEXT,
     type SAMPLE_TYPE, info TEXT);
 
-CREATE TABLE File(id VARCHAR(36) PRIMARY KEY, study_id VARCHAR(36) references Study, name TEXT, size BIGINT,
+CREATE TABLE File(id VARCHAR(36) PRIMARY KEY, analysis_id VARCHAR(36) references Analysis, study_id VARCHAR(36) references Study, name TEXT, size BIGINT,
     md5 CHAR(32), type FILE_TYPE, info TEXT);
-
 CREATE TABLE Analysis(id VARCHAR(36) PRIMARY KEY, type ANALYSIS_TYPE, study_id VARCHAR(36) references Study,
     state ANALYSIS_STATE, info TEXT);
-CREATE TABLE FileSet(analysis_id VARCHAR(36) references Analysis, file_id VARCHAR(36) references File ON DELETE CASCADE);
+CREATE TABLE File(id VARCHAR(36) PRIMARY KEY, analysis_id VARCHAR(36) references Analysis, study_id VARCHAR(36) references Study, name TEXT, size BIGINT,
+                  md5 CHAR(32), type FILE_TYPE, info TEXT);
 CREATE TABLE SampleSet(analysis_id VARCHAR(36) references Analysis, sample_id VARCHAR(36) references Sample);
 CREATE TABLE SequencingRead(id VARCHAR(36) references Analysis, library_strategy LIBRARY_STRATEGY, paired_end BOOLEAN,
     insert_size BIGINT, aligned BOOLEAN, alignment_tool TEXT, reference_genome TEXT, info TEXT);

--- a/song-server/src/test/java/org/icgc/dcc/song/server/service/FileServiceTest.java
+++ b/song-server/src/test/java/org/icgc/dcc/song/server/service/FileServiceTest.java
@@ -50,7 +50,7 @@ public class FileServiceTest {
   public void testReadFile() {
     val id = "FI1";
     val name = "ABC-TC285G7-A5-ae3458712345.bam";
-    val analysis_id="AN1";
+    val analysisId="AN1";
     val study = "ABC123";
     val type = "BAM";
     val size = 122333444455555L;
@@ -58,7 +58,7 @@ public class FileServiceTest {
     val metadata = JsonUtils.fromSingleQuoted("{'info':'<XML>Not even well-formed <XML></XML>'}");
     val file = fileService.read(id);
 
-    val expected = File.create(id, analysis_id, name, study, size, type, md5, metadata);
+    val expected = File.create(id, analysisId, name, study, size, type, md5, metadata);
     assertThat(file).isEqualToComparingFieldByField(expected);
   }
 
@@ -95,7 +95,7 @@ public class FileServiceTest {
 
     val study="ABC123";
     val id = "";
-    val analysis_id="AN1";
+    val analysisId="AN1";
     val name = "file123.fasta";
     val sampleId = "";
     val size = 12345L;
@@ -103,12 +103,12 @@ public class FileServiceTest {
     val md5 = "md5sumaebcefghadwa";
     val metadata = "";
 
-    val s = File.create(id, analysis_id,name, sampleId, size, type, md5, metadata);
+    val s = File.create(id, analysisId,name, sampleId, size, type, md5, metadata);
 
     fileService.create("AN1", study, s);
     val id2 = s.getObjectId();
 
-    val s2 = File.create(id2,  analysis_id,"File 102.fai", study, 123456789L, "FAI", "md5magical", "");
+    val s2 = File.create(id2,  analysisId,"File 102.fai", study, 123456789L, "FAI", "md5magical", "");
     fileService.update(s2);
 
     val s3 = fileService.read(id2);

--- a/song-server/src/test/java/org/icgc/dcc/song/server/service/FileServiceTest.java
+++ b/song-server/src/test/java/org/icgc/dcc/song/server/service/FileServiceTest.java
@@ -50,6 +50,7 @@ public class FileServiceTest {
   public void testReadFile() {
     val id = "FI1";
     val name = "ABC-TC285G7-A5-ae3458712345.bam";
+    val analysis_id="AN1";
     val study = "ABC123";
     val type = "BAM";
     val size = 122333444455555L;
@@ -57,7 +58,7 @@ public class FileServiceTest {
     val metadata = JsonUtils.fromSingleQuoted("{'info':'<XML>Not even well-formed <XML></XML>'}");
     val file = fileService.read(id);
 
-    val expected = File.create(id, name, study, size, type, md5, metadata);
+    val expected = File.create(id, analysis_id, name, study, size, type, md5, metadata);
     assertThat(file).isEqualToComparingFieldByField(expected);
   }
 
@@ -66,6 +67,7 @@ public class FileServiceTest {
     val sampleId = "";
     val studyId="ABC123";
     val f = new File();
+
     f.setObjectId("");
     f.setFileName("ABC-TC285G87-A5-sqrl.bai");
 
@@ -75,7 +77,7 @@ public class FileServiceTest {
     f.setFileType("FAI");
     f.setFileMd5sum("md5abcdefg");
 
-    val status = fileService.create("Analysis123",  studyId, f);
+    val status = fileService.create("AN1",  studyId, f);
     val id = f.getObjectId();
 
     assertThat(status).isEqualTo(id);
@@ -93,6 +95,7 @@ public class FileServiceTest {
 
     val study="ABC123";
     val id = "";
+    val analysis_id="AN1";
     val name = "file123.fasta";
     val sampleId = "";
     val size = 12345L;
@@ -100,12 +103,12 @@ public class FileServiceTest {
     val md5 = "md5sumaebcefghadwa";
     val metadata = "";
 
-    val s = File.create(id, name, sampleId, size, type, md5, metadata);
+    val s = File.create(id, analysis_id,name, sampleId, size, type, md5, metadata);
 
-    fileService.create("Analysis123", study, s);
+    fileService.create("AN1", study, s);
     val id2 = s.getObjectId();
 
-    val s2 = File.create(id2, "File 102.fai", study, 123456789L, "FAI", "md5magical", "");
+    val s2 = File.create(id2,  analysis_id,"File 102.fai", study, 123456789L, "FAI", "md5magical", "");
     fileService.update(s2);
 
     val s3 = fileService.read(id2);


### PR DESCRIPTION
…an analysis Id.

Documentation: Updated METADATA_RULES to clarify behaviour for using analysisSubmitterId versus not. Reference to schemas now references the correct directory. Added a reference to docker directory.