### PR TITLE
Client sing app

### DIFF
--- a/song-client/src/main/assembly/bin.xml
+++ b/song-client/src/main/assembly/bin.xml
@@ -22,12 +22,16 @@
       <outputDirectory>conf</outputDirectory>
     </fileSet>
     <fileSet>
+      <directory>src/main/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+    </fileSet>
+    <fileSet>
       <directory>src/main/resources</directory>
       <outputDirectory>conf</outputDirectory>
       <includes>
         <include>application.yml</include>
       </includes>
-    </fileSet>    
+    </fileSet>
     <fileSet>
       <directory>src/main/lib</directory>
       <outputDirectory>lib</outputDirectory>

--- a/song-client/src/main/bin/sing
+++ b/song-client/src/main/bin/sing
@@ -1,0 +1,8 @@
+current_dir=$PWD
+fn=$0
+sing_home=$current_dir/`dirname $fn`
+#echo "SING_HOME = $sing_home"
+java \
+         -Dspring.config.location="$sing_home/conf/" \
+         -jar $sing_home/lib/song-client.jar \
+         $@

--- a/song-client/src/main/bin/sing
+++ b/song-client/src/main/bin/sing
@@ -1,6 +1,6 @@
 current_dir=$PWD
 fn=$0
-sing_home=$current_dir/`dirname $fn`
+sing_home=$current_dir/`dirname $fn`/../
 #echo "SING_HOME = $sing_home"
 java \
          -Dspring.config.location="$sing_home/conf/" \


### PR DESCRIPTION
- officially wrapped the song-client.jar. once the song-client-0.1.4-SNAPSHOt-dist.tar.gz is untared, all the user has to do is modify the conf/application.yml with the correct server and study, and then they can use use the song service via /bin/sing 