### PR TITLE
enforcing minimum file count in the json schemas

### DIFF
--- a/song-server/src/main/resources/schemas/sequencingRead.json
+++ b/song-server/src/main/resources/schemas/sequencingRead.json
@@ -157,8 +157,9 @@
         }
       }
     },
-    "files": {
+    "file": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {

--- a/song-server/src/main/resources/schemas/variantCall.json
+++ b/song-server/src/main/resources/schemas/variantCall.json
@@ -117,6 +117,7 @@
     },
     "file": {
       "type": "array",
+      "minItems" : 1,
       "items": {
         "type": "object",
         "properties": {

--- a/song-server/src/test/java/org/icgc/dcc/song/server/validation/schemaValidationTests.java
+++ b/song-server/src/test/java/org/icgc/dcc/song/server/validation/schemaValidationTests.java
@@ -18,22 +18,19 @@
  */
 package org.icgc.dcc.song.server.validation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.InputStream;
-import java.util.Set;
-
-//import org.junit.Before;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
-
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 public class schemaValidationTests {
@@ -49,7 +46,7 @@ public class schemaValidationTests {
   public void validate_submit_sequencing_read_missing_required() throws Exception {
     val errors = validate("schemas/sequencingRead.json",
             "documents/sequencingread-missing-required.json");
-    assertThat(errors.size()).isEqualTo(2);
+    assertThat(errors.size()).isEqualTo(3);
   }
 
   @Test


### PR DESCRIPTION
- updated analysis json-schemas to have a minimum file count of 1
- updated the test. previously was only counting 2 errors, where there were actually 3 (file[0].fileName is the third error that was never reported)