### PR TITLE
search by analysis id

### DIFF
--- a/song-client/src/main/java/org/icgc/dcc/song/client/register/Endpoint.java
+++ b/song-client/src/main/java/org/icgc/dcc/song/client/register/Endpoint.java
@@ -55,6 +55,10 @@ public class Endpoint {
     return format("%s/studies/%s/analysis/%s/files", serverUrl, studyId, analysisId);
   }
 
+  public String getAnalysis(String studyId, String analysisId) {
+    return format("%s/studies/%s/analysis/%s", serverUrl, studyId, analysisId);
+  }
+
   public String isAlive() {
     return format("%s/isAlive", serverUrl);
   }

--- a/song-client/src/main/java/org/icgc/dcc/song/client/register/Registry.java
+++ b/song-client/src/main/java/org/icgc/dcc/song/client/register/Registry.java
@@ -82,6 +82,11 @@ public class Registry {
     return restClient.get(accessToken, url);
   }
 
+  public Status getAnalysis(String studyId, String analysisId) {
+    val url = endpoint.getAnalysis(studyId, analysisId);
+    return restClient.get(accessToken, url);
+  }
+
   /**
    * Returns true if the SONG server is running, otherwise false.
    * @return boolean


### PR DESCRIPTION
Search command in the client now supports searching by analysisId. However, this search is mutually exclusive from the others (-f/-d/-sa/-sp), and errors out if the user tries to use them.