### PR TITLE
feature/dcc-5726-disable-entity-endpoints

### DIFF
--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/AnalysisController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/AnalysisController.java
@@ -66,12 +66,15 @@ public class AnalysisController {
     return analysisService.getAnalysis(studyId);
   }
 
-  @PutMapping(consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
-  @SneakyThrows
-  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public ResponseEntity<String> modifyAnalysis(@PathVariable("studyId") String studyId, @RequestBody Analysis analysis) {
-    return analysisService.updateAnalysis(studyId, analysis);
-  }
+  /**
+   * [DCC-5726] - updates disabled until back propagation updates due to business key updates is implemented
+   */
+//  @PutMapping(consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+//  @SneakyThrows
+//  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+//  public ResponseEntity<String> modifyAnalysis(@PathVariable("studyId") String studyId, @RequestBody Analysis analysis) {
+//    return analysisService.updateAnalysis(studyId, analysis);
+//  }
 
   @PutMapping(value="/publish/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
   @SneakyThrows

--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/DonorController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/DonorController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -66,13 +65,16 @@ public class DonorController {
     return donorService.read(id);
   }
 
-  @PutMapping(value = "/donors/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
-  @ResponseBody
-  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public String update(@PathVariable("study") String studyId, @PathVariable("id") String id, @RequestBody Donor donor) {
-    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
-    return donorService.update(donor);
-  }
+  /**
+   * [DCC-5726] - updates disabled until back propagation updates due to business key updates is implemented
+   */
+//  @PutMapping(value = "/donors/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+//  @ResponseBody
+//  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+//  public String update(@PathVariable("study") String studyId, @PathVariable("id") String id, @RequestBody Donor donor) {
+//    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
+//    return donorService.update(donor);
+//  }
 
   @DeleteMapping(value = "/donors/{ids}")
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")

--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/FileController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/FileController.java
@@ -26,9 +26,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,8 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 import static org.icgc.dcc.song.core.utils.Responses.OK;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
 @RequiredArgsConstructor
@@ -57,13 +52,16 @@ public class FileController {
     return fileService.read(id);
   }
 
-  @PutMapping(value = "/files/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
-  @ResponseBody
-  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id, @RequestBody File file) {
-    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
-    return fileService.update(file);
-  }
+  /**
+   * [DCC-5726] - updates disabled until back propagation updates due to business key updates is implemented
+   */
+//  @PutMapping(value = "/files/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+//  @ResponseBody
+//  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+//  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id, @RequestBody File file) {
+//    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
+//    return fileService.update(file);
+//  }
 
   @DeleteMapping(value = "/files/{ids}")
   @ResponseBody

--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/SampleController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/SampleController.java
@@ -19,7 +19,6 @@
 package org.icgc.dcc.song.server.controller;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import org.icgc.dcc.song.server.model.entity.Sample;
 import org.icgc.dcc.song.server.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -65,14 +63,17 @@ public class SampleController {
     return sampleService.read(id);
   }
 
-  @PutMapping(value = "/samples/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
-  @ResponseBody
-  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id,
-                       @RequestBody Sample sample) {
-    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
-    return sampleService.update(sample);
-  }
+  /**
+   * [DCC-5726] - updates disabled until back propagation updates due to business key updates is implemented
+   */
+//  @PutMapping(value = "/samples/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+//  @ResponseBody
+//  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+//  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id,
+//                       @RequestBody Sample sample) {
+//    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
+//    return sampleService.update(sample);
+//  }
 
   @DeleteMapping(value = "/samples/{ids}")
   @ResponseBody

--- a/song-server/src/main/java/org/icgc/dcc/song/server/controller/SpecimenController.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/controller/SpecimenController.java
@@ -19,7 +19,6 @@
 package org.icgc.dcc.song.server.controller;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import org.icgc.dcc.song.server.model.entity.Specimen;
 import org.icgc.dcc.song.server.service.SpecimenService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -65,14 +63,17 @@ public class SpecimenController {
     return specimenService.read(id);
   }
 
-  @PutMapping(value = "/specimens/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
-  @ResponseBody
-  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id,
-                       @RequestBody Specimen specimen) {
-    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
-    return specimenService.update(specimen);
-  }
+  /**
+   * [DCC-5726] - updates disabled until back propagation updates due to business key updates is implemented
+   */
+//  @PutMapping(value = "/specimens/{id}", consumes = { APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE })
+//  @ResponseBody
+//  @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
+//  public String update(@PathVariable("studyId") String studyId, @PathVariable("id") String id,
+//                       @RequestBody Specimen specimen) {
+//    // TODO: [DCC-5642] Add checkRequest between path ID and Entity's ID
+//    return specimenService.update(specimen);
+//  }
 
   @DeleteMapping(value = "/specimens/{ids}")
   @ResponseBody


### PR DESCRIPTION
commented out update endpoints for each controller. Temporary until back propagation updating is implemented when a business key is updated