### PR TITLE
updated release versions

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,8 +1,9 @@
 FROM song_base-ubuntu:latest
 MAINTAINER ICGC <dcc-support@icgc.org>
 
+ENV CLIENT_RELEASE_VERSION 0.3.4
 ENV CLIENT_HOME $DCC_DATA
-ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-client/[RELEASE]/song-client-[RELEASE]-dist.tar.gz
+ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-client/${CLIENT_RELEASE_VERSION}/song-client-${CLIENT_RELEASE_VERSION}-dist.tar.gz
 ENV TARBALL $DCC_HOME/download.tar.gz
 
 ADD config $DCC_CONFIG

--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,10 +1,11 @@
 FROM song_base-db:latest
 MAINTAINER ICGC <dcc-support@icgc.org>
 
+ENV SERVER_RELEASE_VERSION 0.3.4
 ENV PGDATA /var/lib/postgresql/data/pgdata
 ENV POSTGRES_INIT_SQL /docker-entrypoint-initdb.d/init.sql
 
-ENV DOWNLOAD_URL https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-server/[RELEASE]/song-server-[RELEASE].jar 
+ENV DOWNLOAD_URL https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-server/${SERVER_RELEASE_VERSION}/song-server-${SERVER_RELEASE_VERSION}.jar 
 ENV JAR  $DCC_HOME/song-server.jar
 ENV INIT_FILE /docker-entrypoint-initdb.d/init.sh
 

--- a/docker/id-db/Dockerfile
+++ b/docker/id-db/Dockerfile
@@ -1,9 +1,10 @@
 FROM song_base-db:latest
 MAINTAINER ICGC <dcc-support@icgc.org>
 
+ENV ID_RELEASE_VERSION 5.1.1
 ENV PGDATA /var/lib/postgresql/data/pgdata
 ENV POSTGRES_INIT_SQL /docker-entrypoint-initdb.d/init.sql
-ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/dcc-id-server/[RELEASE]/dcc-id-server-[RELEASE].jar 
+ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/dcc-id-server/${ID_RELEASE_VERSION}/dcc-id-server-${ID_RELEASE_VERSION}.jar 
 ENV JARFILE $DCC_HOME/dcc-id-server.jar
 
 RUN wget $DOWNLOAD_URL -O $JARFILE && \

--- a/docker/id/Dockerfile
+++ b/docker/id/Dockerfile
@@ -1,10 +1,11 @@
 FROM song_base-ubuntu:latest
 MAINTAINER ICGC <dcc-support@icgc.org>
 
+ENV ID_RELEASE_VERSION 5.1.1
 ENV ID_HOME $DCC_HOME/dcc-id-server
 ENV ID_SCRIPTS $DCC_HOME/scripts
 ENV TARBALL $DCC_HOME/dcc-id-server.tar.gz
-ENV DOWNLOAD_URL https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/dcc-id-server/[RELEASE]/dcc-id-server-[RELEASE]-dist.tar.gz
+ENV DOWNLOAD_URL https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/dcc-id-server/${ID_RELEASE_VERSION}/dcc-id-server-${ID_RELEASE_VERSION}-dist.tar.gz
 
 ADD config $DCC_CONFIG
 ADD scripts $ID_SCRIPTS

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,9 +4,10 @@ MAINTAINER ICGC <dcc-support@icgc.org>
 #
 # Configuration
 #
+ENV SERVER_RELEASE_VERSION 0.3.4
 ENV SONG_HOME $DCC_HOME/song-server
 ENV SONG_LOGS $DCC_HOME/song-server/logs
-ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-server/[RELEASE]/song-server-[RELEASE]-dist.tar.gz  
+ENV DOWNLOAD_URL  https://artifacts.oicr.on.ca/artifactory/dcc-release/org/icgc/dcc/song-server/${SERVER_RELEASE_VERSION}/song-server-${SERVER_RELEASE_VERSION}-dist.tar.gz  
 ENV TARBALL $DCC_HOME/song-server.tar.gz
 
 ADD config $DCC_CONFIG

--- a/docker/server/config/application.yml.template
+++ b/docker/server/config/application.yml.template
@@ -32,6 +32,7 @@ id:
   idUrl: "${ID_URL}"
   authToken: "${AUTH_TOKEN}"
   realIds: true
+  persistInMemory: false
 
 validation:
   threads:
@@ -71,6 +72,7 @@ spring:
 
 auth:
   server:
+    prefix: "song"
     suffix: "upload"
 
 # Datasource
@@ -95,6 +97,7 @@ auth:
     clientSecret: "${AUTH_SERVER_CLIENTSECRET}"
     enableStrictSSL: false
     enableHttpLogging: false
+    prefix: "song"
     suffix: "upload"
 ---
 
@@ -135,4 +138,4 @@ spring:
   profiles: test
   autoconfigure.exclude: SecurityConfig.class
 
-  
+id.persistInMemory: true 


### PR DESCRIPTION
previously release versions were "latest". now hardcoded them, so docker will always build regardless of the updates